### PR TITLE
feat(CI): changelog file generation on commit

### DIFF
--- a/.github/workflows/ci-commit-changelog.yaml
+++ b/.github/workflows/ci-commit-changelog.yaml
@@ -1,0 +1,35 @@
+name: Update CHANGELOG.md on commit
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update-changelog:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22
+
+    - name: Install dependencies
+      run: npm install -g conventional-changelog-cli
+
+    - name: Generate CHANGELOG.md
+      run: conventional-changelog -p angular -o CHANGELOG.md -r 0
+
+    - name: Commit and push changes
+      run: |
+        git config --global user.name 'github-actions'
+        git config --global user.email 'actions@github.com'
+        git add CHANGELOG.md
+        git commit -m "chore: :robot: updated CHANGELOG.md"
+        git push
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Added automatic generation and update of `CHANGELOG.md` file upon commit on main branch.

For additional documentation on the generation step refer to [this guide](https://github.com/marketplace/actions/generate-changelog-action).
NOTE: weirdly enough, the generator step requires an (empty) `package.json` file as it was originally created for node projects only.

This also requires all commits to be in format `feat(Compiler): xxx`, so I will probabily rename commits on the develop branch.

This solves #4 

### Example

```md
#  1.0.0 (2024-11-16)

### Features

* implement Poetry ([e30cbc1](https://github.com/d-u-d-e/c-compiler/commit/e30cbc14a6ac9e3637447bce10a7487d3bacb07f))

```