### PR TITLE
Using a deploy key to bypass branch protection rules

### DIFF
--- a/.github/workflows/ci-commit-changelog.yaml
+++ b/.github/workflows/ci-commit-changelog.yaml
@@ -28,6 +28,8 @@ jobs:
       run: conventional-changelog -p angular -o CHANGELOG.md -r 0
 
     - name: Commit and push changes
+      with:
+        ssh-key: ${{ secrets.DEPLOY_KEY_PRV }}
       run: |
         git config --global user.name 'github-actions'
         git config --global user.email 'actions@github.com'


### PR DESCRIPTION
bypass branch protection rules for changelog updater